### PR TITLE
update julia installation notebook

### DIFF
--- a/docs/installing_julia_and_ijulia.ipynb
+++ b/docs/installing_julia_and_ijulia.ipynb
@@ -4,21 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Installating Julia/IJulia (version of 2019-08-25)\n",
+    "# Installating Julia/IJulia \n",
     "\n",
-    "### Warning: as of 2019-08-25, the Julia installation is not supposed to support a move of Winpython library\n",
-    "\n",
-    "read also https://pyjulia.readthedocs.io/en/latest/installation.html#step-1-install-julia\n",
-    "\n",
-    "other intesting note:\n",
-    "or https://discourse.julialang.org/t/using-jupyterlab/20595/2\n",
-    "or https://blog.jupyter.org/i-python-you-r-we-julia-baf064ca1fb6\n",
-    "\n",
-    "###0 - mandatory and only pre-requisites (prepared, in  WinPython 2019-03+)\n",
-    "\"pip install pyjulia\"      pyjulia python package\n",
-    "\"set PYTHON=%WINDPYDIR%\\python.exe\"   in your %WINPYDIR%..\\scripts\\ENV.BAT\n",
-    "\n",
-    "###1 - Downloading and Installing the right Julia binary in the right place"
+    "### 1 - Downloading and Installing the right Julia binary in the right place"
    ]
   },
   {
@@ -29,7 +17,8 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import io"
+    "import io\n",
+    "import re"
    ]
   },
   {
@@ -38,24 +27,94 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# downloading julia (32Mo, may take 1 minute or 2)\n",
-    "try:\n",
-    "    import urllib.request as urllib2  # Python 3\n",
-    "except:\n",
-    "    import urllib2  # Python 2\n",
+    "import urllib.request as request  # Python 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get latest stable release info, download link and hashes\n",
+    "g = request.urlopen(\"https://julialang.org/downloads/\")\n",
+    "s = g.read().decode()\n",
+    "g.close;\n",
+    "\n",
+    "r = r'<a href=\".current_stable_release\">([^<]+)</a></h2> ' + \\\n",
+    "    r'<p>Checksums for this release are available in both <a href=\"([^\"]*)\">MD5</a> and <a href=\"([^\"]*)\">SHA256</a> formats.</p>' + \\\n",
+    "    r'[^W]*Windows <a href=\"/downloads/platform/.windows\">.help.</a> <td colspan=3 > <a href=\"[^\"]*\">64-bit .installer.</a>, <a href=\"([^\"]*)\">64-bit .portable.</a>' + \\\n",
+    "    r' <td colspan=3 > <a href=\"[^\"]*\">32-bit .installer.</a>, <a href=\"([^\"]*)\">32-bit .portable.</a>'\n",
+    "\n",
+    "release_str, md5link, sha256link, ziplink64bit, ziplink32bit  = re.findall(r,s)[0]\n",
+    "julia_version=re.findall(r\"v([^\\s]+)\",release_str)[0]\n",
+    "print(release_str)\n",
+    "print(julia_version)\n",
+    "print(ziplink64bit)\n",
+    "print(ziplink32bit)\n",
+    "print(md5link)\n",
+    "print(sha256link)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "overwrite links, since v1.5.3 installation does not work properly due to\n",
+    "https://github.com/JuliaLang/julia/issues/38411"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if julia_version=='1.5.3':\n",
+    "    julia_version='1.6.0-rc1'\n",
+    "    ziplink64bit='https://julialang-s3.julialang.org/bin/winnt/x64/1.6/julia-1.6.0-rc1-win64.zip'\n",
+    "    md5link='https://julialang-s3.julialang.org/bin/checksums/julia-1.6.0-rc1.md5'\n",
+    "    sha256link='https://julialang-s3.julialang.org/bin/checksums/julia-1.6.0-rc1.sha256'\n",
+    "    print(julia_version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# download checksums\n",
+    "g = request.urlopen(md5link)\n",
+    "md5hashes = g.read().decode()\n",
+    "g.close;\n",
+    "\n",
+    "g = request.urlopen(sha256link)\n",
+    "sha256hashes = g.read().decode()\n",
+    "g.close;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# downloading julia (may take 1 minute or 2)\n",
+    "\n",
     "if 'amd64' in sys.version.lower():\n",
-    "    julia_binary=\"julia-1.2.0-win64.exe\"\n",
-    "    julia_url=\"https://julialang-s3.julialang.org/bin/winnt/x64/1.2/julia-1.2.0-win64.exe\"\n",
-    "    hashes=(\"5ccb7d585f854f3a3d1c6d3db07b6c0f\", \"93A94ED6429463E585B7B7E2CAC079F92820F71D\" )\n",
+    "    julia_zip=ziplink64bit.split(\"/\")[-1]\n",
+    "    julia_url=ziplink64bit\n",
     "else:\n",
-    "    julia_binary=\"julia-1.2.0-win32.exe\"\n",
-    "    julia_url=\"https://julialang-s3.julialang.org/bin/winnt/x86/1.2/julia-1.2.0-win32.exe\"\n",
-    "    hashes=(\"a2a0ab81bd639339970248c808316f23\", \"b5e0e5b6f0e5a737f4de9baa758b3ab50e2d52cb\")\n",
+    "    julia_zip=ziplink32bit.split(\"/\")[-1]\n",
+    "    julia_url=ziplink32bit\n",
     "    \n",
-    "julia_installer=os.environ[\"WINPYDIR\"]+\"\\\\..\\\\t\\\\\"+julia_binary\n",
-    "os.environ[\"julia_installer\"]=julia_installer\n",
-    "g = urllib2.urlopen(julia_url) \n",
-    "with io.open(julia_installer, 'wb') as f:\n",
+    "hashes=(re.findall(r\"([0-9a-f]{32})\\s\"+julia_zip, md5hashes)[0] , re.findall(r\"([0-9a-f]{64})\\s+\"+julia_zip, sha256hashes)[0])\n",
+    "    \n",
+    "julia_zip_fullpath = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", julia_zip)\n",
+    "\n",
+    "g = request.urlopen(julia_url) \n",
+    "with io.open(julia_zip_fullpath, 'wb') as f:\n",
     "    f.write(g.read())\n",
     "g.close\n",
     "g = None"
@@ -68,7 +127,7 @@
    "outputs": [],
    "source": [
     "#checking it's there\n",
-    "!dir %julia_installer%"
+    "assert os.path.isfile(julia_zip_fullpath)"
    ]
   },
   {
@@ -77,16 +136,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# checking it's the official julia0.3.2\n",
+    "# checking the hashes\n",
     "import hashlib\n",
     "def give_hash(of_file, with_this):\n",
-    "    with io.open(julia_installer, 'rb') as f:\n",
+    "    with io.open(julia_zip_fullpath, 'rb') as f:\n",
     "        return with_this(f.read()).hexdigest()  \n",
-    "print (\" \"*12+\"MD5\"+\" \"*(32-12-3)+\" \"+\" \"*15+\"SHA-1\"+\" \"*(40-15-5)+\"\\n\"+\"-\"*32+\" \"+\"-\"*40)\n",
+    "print (\" \"*12+\"MD5\"+\" \"*(32-12-3)+\" \"+\" \"*15+\"SHA-256\"+\" \"*(40-15-5)+\"\\n\"+\"-\"*32+\" \"+\"-\"*64)\n",
     "\n",
-    "print (\"%s %s %s\" % (give_hash(julia_installer, hashlib.md5) , give_hash(julia_installer, hashlib.sha1),julia_installer))\n",
-    "assert give_hash(julia_installer, hashlib.md5) == hashes[0].lower() \n",
-    "assert give_hash(julia_installer, hashlib.sha1) ==  hashes[1].lower()"
+    "print (\"%s %s %s\" % (give_hash(julia_zip_fullpath, hashlib.md5) , give_hash(julia_zip_fullpath, hashlib.sha256),julia_zip))\n",
+    "assert give_hash(julia_zip_fullpath, hashlib.md5)  ==  hashes[0].lower() \n",
+    "assert give_hash(julia_zip_fullpath, hashlib.sha256) ==  hashes[1].lower()"
    ]
   },
   {
@@ -96,13 +155,19 @@
    "outputs": [],
    "source": [
     "# will be in env next time\n",
-    "import os\n",
-    "os.environ[\"JULIA_HOME\"] = os.environ[\"WINPYDIR\"]+\"\\\\..\\\\t\\\\Julia\\\\bin\\\\\"\n",
-    "os.environ[\"JULIA_EXE\"]=\"julia.exe\"\n",
-    "os.environ[\"JULIA\"]=os.environ[\"JULIA_HOME\"]+os.environ[\"JULIA_EXE\"]\n",
-    "os.environ[\"JULIA_PKGDIR\"]=os.environ[\"WINPYDIRBASE\"]+\"\\\\settings\\\\.julia\"\n",
-    "# for installation we need this\n",
-    "os.environ[\"JULIAROOT\"]=os.path.join(os.path.split(os.environ[\"WINPYDIR\"])[0]  , 't','julia' )  "
+    "os.environ[\"JUPYTER\"] = os.path.join(os.environ[\"WINPYDIR\"],\"Scripts\",\"jupyter.exe\")\n",
+    "os.environ[\"JULIA_HOME\"] = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"julia-\"+julia_version)\n",
+    "os.environ[\"JULIA_EXE_PATH\"] = os.path.join(os.environ[\"JULIA_HOME\"], \"bin\")\n",
+    "os.environ[\"JULIA_EXE\"] = \"julia.exe\"\n",
+    "os.environ[\"JULIA\"] = os.path.join(os.environ[\"JULIA_EXE_PATH\"],os.environ[\"JULIA_EXE\"])\n",
+    "os.environ[\"JULIA_PKGDIR\"] = os.path.join(os.environ[\"WINPYDIRBASE\"],\"settings\",\".julia\")\n",
+    "os.environ[\"JULIA_DEPOT_PATH\"] = os.environ[\"JULIA_PKGDIR\"] \n",
+    "os.environ[\"JULIA_HISTORY\"] = os.path.join(os.environ[\"JULIA_PKGDIR\"],\"logs\",\"repl_history.jl\")\n",
+    "os.environ[\"CONDA_JL_HOME\"] = os.path.join(os.environ[\"JULIA_HOME\"], \"conda\", \"3\")\n",
+    "\n",
+    "\n",
+    "# move JULIA_EXE_PATH to the beginning of PATH, since a julia installation may be present on the machine\n",
+    "os.environ[\"PATH\"] = os.environ[\"JULIA_EXE_PATH\"] + \";\" + os.environ[\"PATH\"]"
    ]
   },
   {
@@ -111,26 +176,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# let's install it (add a  /S before /D if you want silence mode installation)\n",
-    "#nullsoft installers don't accept . or .. conventions\n",
-    "\n",
-    "# If you are \"USB life style\", or multi-winpython\n",
-    "#   ==> UN-CLICK the OPTION 'CREATE a StartMenuFolder and Shortcut' <== (when it will show up)\n",
-    "!start cmd /C %julia_installer% /D=%JULIAROOT%\n"
+    "if not os.path.isdir(os.environ[\"JULIA_PKGDIR\"]):\n",
+    "    os.mkdir(os.environ[\"JULIA_PKGDIR\"])\n",
+    "    \n",
+    "if not os.path.isdir(os.path.join(os.environ[\"JULIA_PKGDIR\"],\"logs\")):\n",
+    "    os.mkdir(os.path.join(os.environ[\"JULIA_PKGDIR\"],\"logs\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.isfile(os.environ[\"JULIA_HISTORY\"]):\n",
+    "    open(os.environ[\"JULIA_HISTORY\"], 'a').close() # create empty file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract the zip archive\n",
+    "import zipfile\n",
+    "try:\n",
+    "    with zipfile.ZipFile(julia_zip_fullpath) as z:\n",
+    "        z.extractall(os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\"))\n",
+    "        print(\"Extracted all files\")\n",
+    "except:\n",
+    "    print(\"Invalid file\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete zip file\n",
+    "os.remove(julia_zip_fullpath)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://raw.githubusercontent.com/stonebig/winpython_afterdoc/master/examples/images/julia_setup_unclick_all.GIF\">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "###2 - Initialize Julia , IJulia, and make them link to winpython"
+    "### 2 - Initialize Julia , IJulia, and make them link to winpython"
    ]
   },
   {
@@ -140,6 +233,8 @@
    "outputs": [],
    "source": [
     "# connecting Julia to WinPython (only once, or everytime you move things)\n",
+    "# see the Windows terminal window for the detailed status. This may take \n",
+    "# a minute or two.\n",
     "import julia\n",
     "julia.install()"
    ]
@@ -159,21 +254,181 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%julia  \n",
-    "import Pkg;\n",
-    "Pkg.add(\"PyPlot\")\n",
-    "Pkg.add(\"Interact\")\n",
-    "Pkg.add(\"Compose\")\n",
-    "Pkg.add(\"SymPy\")\n",
-    "Pkg.add(\"JuMP\")\n",
-    "Pkg.add(\"Ipopt\")"
+    "info = julia.juliainfo.JuliaInfo.load()\n",
+    "print(info.julia)\n",
+    "print(info.sysimage)\n",
+    "print(info.version_raw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from julia.api import Julia\n",
+    "jl = Julia(compiled_modules=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sanity check\n",
+    "assert jl.eval(\"1+2\") == 3"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###3 - Launching a Julia Notebook \n",
+    "#### Print julia's versioninfo()\n",
+    "The environment should point to the usb drive and not to C:\\\\ (your local installation of julia maybe...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jl.eval(\"using InteractiveUtils\")\n",
+    "jl.eval('file = open(\"julia_versioninfo.txt\",\"w\")')  \n",
+    "jl.eval(\"versioninfo(file,verbose=false)\")\n",
+    "jl.eval(\"close(file)\")\n",
+    "\n",
+    "with open('julia_versioninfo.txt', 'r') as f:\n",
+    "    print(f.read())\n",
+    "    \n",
+    "os.remove('julia_versioninfo.txt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Install julia Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%julia\n",
+    "using Pkg\n",
+    "\n",
+    "Pkg.instantiate()\n",
+    "Pkg.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%julia\n",
+    "# add useful packages. Again, this may take a while...\n",
+    "Pkg.add(\"IJulia\")\n",
+    "Pkg.add(\"Plots\")\n",
+    "Pkg.add(\"Interact\")\n",
+    "Pkg.add(\"Compose\")\n",
+    "Pkg.add(\"SymPy\")\n",
+    "\n",
+    "using Compose\n",
+    "using SymPy\n",
+    "using IJulia\n",
+    "using Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Fix the kernel.json to allow arbitrary drive letters and modify the env.bat\n",
+    "\n",
+    "the path to kernel.jl is hardcoded in the kernel.json file\n",
+    "this will cause trouble, if the drive letter of the usb drive changes\n",
+    "use relative paths instead\n",
+    "rewrite kernel.json and delete the one created from IJulia.jl Package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kernel_path = os.path.join(os.environ[\"WINPYDIRBASE\"], \"settings\", \"kernels\", \"julia-\"+julia_version[0:3])\n",
+    "assert os.path.isdir(kernel_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(kernel_path,\"kernel.json\"), 'r') as f:\n",
+    "    kernel_str = f.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_kernel_str = kernel_str.replace(os.environ[\"WINPYDIRBASE\"].replace(\"\\\\\",\"\\\\\\\\\"),\"{prefix}\\\\\\\\..\")\n",
+    "print(new_kernel_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(kernel_path,\"kernel.json\"), 'w') as f:\n",
+    "    f.write(new_kernel_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add JULIA env variables to env.bat\n",
+    "inp_str = r\"\"\"\n",
+    "rem ******************\n",
+    "rem handle Julia {0} if included\n",
+    "rem ******************\n",
+    "\n",
+    "if not exist \"%WINPYDIRBASE%\\t\\julia-{0}\\bin\" goto julia_bad_{0}\n",
+    "set JULIA_PKGDIR=%WINPYDIRBASE%\\settings\\.julia\n",
+    "set JULIA_DEPOT_PATH=%JULIA_PKGDIR%\n",
+    "set JULIA_EXE=julia.exe\n",
+    "set JULIA_HOME=%WINPYDIRBASE%\\t\\julia-{0}\n",
+    "set JULIA_HISTORY=%JULIA_PKGDIR%\\logs\\repl_history.jl\n",
+    ":julia_bad_{0}\n",
+    "\n",
+    "\"\"\".format(julia_version)\n",
+    "\n",
+    "# append to env.bat\n",
+    "with open(os.path.join(os.environ[\"WINPYDIRBASE\"],\"scripts\",\"env.bat\"), 'a') as file :\n",
+    "    file.write(inp_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3 - Launching a Julia Notebook \n",
     "\n",
     "choose a Julia Kernel from Notebook, or Julia from Jupyterlab Launcher\n",
     "\n"
@@ -183,64 +438,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###4 - Julia Magic \n",
+    "### 4 - Julia Magic \n",
     "or use %load_ext julia.magic then %julia or %%julia"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import julia\n",
-    "%matplotlib inline\n",
-    "%load_ext julia.magic"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# since Julia 1.x ''@pyimport foo' is replaced per 'foo = pyimport(\"foo\")'' \n",
-    "%julia plt = pyimport(\"matplotlib.pyplot\")\n",
-    "%julia np = pyimport(\"numpy\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%julia                                        \n",
-    "t = np.linspace(0, 2*pi,1000);             \n",
-    "s = np.sin(3*t + 4*np.cos(2*t));           \n",
-    "fig = plt.gcf()                         \n",
-    "plt.plot(t, s, color=\"red\", linewidth=2.0, linestyle=\"--\", label=\"sin(3t+4.cos(2t))\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Alternative\n",
-    "import julia\n",
-    "j=julia.Julia()\n",
-    "j.eval(\"1 +31\")\n",
-    "j.eval(\"sqrt(1 +31)\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -259,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This will install the current stable release of julia and the IJulia kernel. 

The regular expressions will probably fail, if the [julia website](julialang.org) is structured differently. 

As noted, the installation of julia v1.5.3 with this notebook will fail due to https://github.com/JuliaLang/julia/issues/38411 and v1.6.0-rc1 is installed instead. 