### PR TITLE
update R installation notebook

### DIFF
--- a/docs/installing_R.ipynb
+++ b/docs/installing_R.ipynb
@@ -4,14 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Installating R on WinPython (version of 2019-08-25)\n",
-    "\n",
-    "### Warning: as of 2019-08-25, the R installation is not supposed to support a move of Winpython library\n",
-    "\n",
-    "see https://richpauloo.github.io/2018-05-16-Installing-the-R-kernel-in-Jupyter-Lab/\n",
-    "\n",
-    "#### This procedure applys for Winpython  (Version of December 2015 and after) \n",
-    "### 1 - Downloading R binary"
+    "# Installating R"
    ]
   },
   {
@@ -23,68 +16,95 @@
     "import os\n",
     "import sys\n",
     "import io\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request as request  # Python 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get latest stable portable release download link \n",
+    "# the vorboss server (UK) does not redirect back to sourceforge\n",
+    "base_url = \"https://vorboss.dl.sourceforge.net/project/rportable/R-Portable/\"\n",
+    "g = request.urlopen(base_url)\n",
+    "s = g.read().decode()\n",
+    "g.close;\n",
     "\n",
-    "# downloading R may takes a few minutes (80Mo)\n",
-    "try:\n",
-    "    import urllib.request as urllib2  # Python 3\n",
-    "except:\n",
-    "    import urllib2  # Python 2\n",
-    "\n",
-    "# specify R binary and (md5, sha1) hash\n",
-    "# R-3.6.1:\n",
-    "r_url = \"https://cran.r-project.org/bin/windows/base/old/3.6.1/R-3.6.1-win.exe\"\n",
-    "hashes=(\"f6ca2ecfc66a10a196991b6b6c4e91f6\",\"df4ad3c36e193423ebf2d698186feded15777da1\")\n",
-    "\n",
-    "# specify target location\n",
-    "# tweak change in recent winpython\n",
-    "tool_base_directory=os.environ[\"WINPYDIR\"]+\"\\\\..\\\\t\\\\\"\n",
-    "if not os.path.isdir(tool_base_directory):\n",
-    "    tool_base_directory=os.environ[\"WINPYDIR\"]+\"\\\\..\\\\tools\\\\\"\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "r_installer = tool_base_directory+os.path.basename(r_url)\n",
-    "os.environ[\"r_installer\"] = r_installer\n",
-    "\n",
-    "# Download\n",
-    "g = urllib2.urlopen(r_url) \n",
-    "with io.open(r_installer, 'wb') as f:\n",
+    "R_version = re.findall(r'<a href=\"(\\d\\.\\d\\.\\d)/\">',s)[-1]\n",
+    "print(\"R Version: \"+R_version)\n",
+    "paflink = base_url+R_version+\"/R-Portable_\"+R_version+\".paf.exe\"\n",
+    "R_installer_fullpath = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"R.paf.exe\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# start download\n",
+    "g = request.urlopen(paflink) \n",
+    "with io.open(R_installer_fullpath, 'wb') as f:\n",
+    "    f.write(g.read())\n",
+    "g.close\n",
+    "g = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking it's there\n",
+    "assert os.path.isfile(R_installer_fullpath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### download 7zip to extract R.paf.exe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# first download version 9.20, since it is availabe as zip\n",
+    "sevenzip_dl_url = \"https://vorboss.dl.sourceforge.net/project/sevenzip/7-Zip/9.20/7za920.zip\"\n",
+    "sevenzip_file = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"7za920.zip\")\n",
+    "g = request.urlopen(sevenzip_dl_url) \n",
+    "with io.open(sevenzip_file, 'wb') as f:\n",
     "    f.write(g.read())\n",
     "g.close\n",
     "g = None\n",
     "\n",
-    "#checking it's there\n",
-    "!dir %r_installer%"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "import zipfile\n",
+    "try:\n",
+    "    with zipfile.ZipFile(sevenzip_file) as z:\n",
+    "        sevenzip_install_dir = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"7za920\")\n",
+    "        os.mkdir(sevenzip_install_dir)\n",
+    "        z.extractall(sevenzip_install_dir)\n",
+    "        print(\"Extracted 7zip v9.20\")\n",
+    "except:\n",
+    "    print(\"Invalid file\")\n",
     "\n",
-    "### 2 - checking and Installing R binary in the right place"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# checking it's the official R\n",
-    "import hashlib\n",
-    "def give_hash(of_file, with_this):\n",
-    "    with io.open(r_installer, 'rb') as f:\n",
-    "        return with_this(f.read()).hexdigest()  \n",
-    "print (\" \"*12+\"MD5\"+\" \"*(32-12-3)+\" \"+\" \"*15+\"SHA-1\"+\" \"*(40-15-5)+\"\\n\"+\"-\"*32+\" \"+\"-\"*40)\n",
-    "print (\"%s %s %s\" % (give_hash(r_installer, hashlib.md5) , give_hash(r_installer, hashlib.sha1),r_installer))\n",
-    "if give_hash(r_installer, hashlib.md5) == hashes[0] and give_hash(r_installer, hashlib.sha1) == hashes[1]:\n",
-    "   print(\"looks good!\")\n",
-    "else:\n",
-    "   print(\"problem ! please check\")\n",
-    "   assert give_hash(r_installer, hashlib.md5) == hashes[0]\n",
-    "   assert give_hash(r_installer, hashlib.sha1) == hashes[1]"
+    "os.remove(sevenzip_file)\n",
+    "sevenzip_exe = os.path.join(sevenzip_install_dir,\"7za.exe\")"
    ]
   },
   {
@@ -93,17 +113,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# preparing Dos variables\n",
-    "os.environ[\"R_HOME\"] = tool_base_directory+ \"R\\\\\" \n",
-    "os.environ[\"R_HOMEbin\"]=os.environ[\"R_HOME\"] + \"bin\" \n",
-    "\n",
-    "# for installation we need this\n",
-    "os.environ[\"tmp_Rbase\"]=os.path.join(os.path.split(os.environ[\"WINPYDIR\"])[0]  , 't','R' )  \n",
-    "if 'amd64' in sys.version.lower():\n",
-    "    r_comp ='/COMPONENTS=\"main,x64,translations'\n",
-    "else:\n",
-    "    r_comp ='/COMPONENTS=\"main,i386,translations'\n",
-    "os.environ[\"tmp_R_comp\"]=r_comp\n"
+    "# then download version 19.00\n",
+    "sevenzip_dl_url = \"https://vorboss.dl.sourceforge.net/project/sevenzip/7-Zip/19.00/7z1900.exe\"\n",
+    "sevenzip_file = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"7z1900.exe\")\n",
+    "g = request.urlopen(sevenzip_dl_url) \n",
+    "with io.open(sevenzip_file, 'wb') as f:\n",
+    "    f.write(g.read())\n",
+    "g.close\n",
+    "g = None"
    ]
   },
   {
@@ -112,42 +129,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# let's install it, if hashes do match\n",
-    "assert give_hash(r_installer, hashlib.md5) == hashes[0]\n",
-    "assert give_hash(r_installer, hashlib.sha1) == hashes[1]\n",
-    "# If you are \"USB life style\", or multi-winpython\n",
-    "#   ==> CLICK the OPTION \"Don't create a StartMenuFolder' <== (when it will show up)\n",
+    "# and extract 7zip v19.00  with 7zip v9.20\n",
+    "from subprocess import run\n",
+    "extr_path = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"7z\")\n",
+    "proc = run(sevenzip_exe+' x '+ sevenzip_file + ' -o' + extr_path)\n",
+    "assert proc.returncode == 0\n",
     "\n",
-    "!start cmd /C %r_installer% /DIR=%tmp_Rbase% %tmp_R_comp%"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## During Installation (if you wan't to move the R installation after)\n",
+    "# remove old 7zip version and 7z archive\n",
+    "import shutil\n",
+    "shutil.rmtree(sevenzip_install_dir)\n",
+    "os.remove(sevenzip_file)\n",
     "\n",
-    "Choose non default option \"Yes (customized startup\"\n",
-    "\n",
-    "then after 3 screens, Select  \"Don't create a Start Menu Folder\"\n",
-    "\n",
-    "Un-select \"Create a desktop icon\"\n",
-    "\n",
-    "Un-select \"Save version number in registery\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"https://raw.githubusercontent.com/stonebig/winpython_afterdoc/master/examples/images/r_setup_unclick_shortcut.GIF\">"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3 - create a R_launcher and install irkernel"
+    "sevenzip_exe=os.path.join(extr_path,\"7z.exe\")"
    ]
   },
   {
@@ -156,81 +149,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import sys\n",
-    "import io\n",
-    "# let's create a R launcher  \n",
-    "r_launcher = r\"\"\"\n",
-    "@echo off\n",
-    "call %~dp0env.bat\n",
-    "rscript %*\n",
-    "\"\"\"\n",
-    "r_launcher_bat = os.environ[\"WINPYDIR\"]+\"\\\\..\\\\scripts\\\\R_launcher.bat\"\n",
-    "\n",
-    "# let's create a R init script\n",
-    "# in manual command line, you can use repos = c('http://irkernel.github.io/', getOption('repos'))\n",
-    "r_initialization = r\"\"\"\n",
-    "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'devtools', 'uuid', 'digest', 'stringr'), repos = c('http://cran.rstudio.com/', 'http://cran.rstudio.com/'))\n",
+    "# extract R.paf.exe\n",
+    "extr_path = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"R-Portable\")\n",
+    "proc = run(sevenzip_exe+' x '+ R_installer_fullpath + ' -x!$* -o' + extr_path) # do not extract the $PLUGINSDIR folder\n",
+    "assert proc.returncode == 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### write a R script to install necessary packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Rscript_text = r\"\"\"\n",
+    "install.packages(c('stringi'),repos=\"https://cloud.r-project.org/\",type=\"binary\")\n",
+    "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'devtools', 'uuid', 'digest'),repos=\"https://cloud.r-project.org/\",type=\"binary\")\n",
     "devtools::install_github('IRkernel/IRkernel')\n",
-    "library('pbdZMQ')\n",
-    "library('repr')\n",
-    "library('IRkernel')\n",
-    "library('IRdisplay')\n",
-    "library('crayon')\n",
-    "library('stringr')\n",
     "IRkernel::installspec()\n",
     "\"\"\"\n",
-    "# IRkernel::installspec() # install for the current user: \n",
-    "# IRkernel::installspec(user = FALSE) # install system-wide\n",
-    "r_initialization_r = os.path.normpath(os.environ[\"WINPYDIR\"]+\"\\\\..\\\\scripts\\\\R_initialization.r\")\n",
     "\n",
-    "\n",
-    "for i in [(r_launcher,r_launcher_bat), (r_initialization, r_initialization_r)]:\n",
-    "    with io.open(i[1], 'w', encoding = sys.getdefaultencoding() ) as f:\n",
-    "        for line in i[0].splitlines():\n",
-    "            f.write('%s\\n' %  line  )\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#check what we are going to do \n",
-    "print (\"!start cmd /C %WINPYDIR%\\\\..\\\\scripts\\\\R_launcher.bat --no-restore --no-save  \" + r_initialization_r)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Launch Rkernel setup\n",
-    "os.environ[\"r_initialization_r\"] = r_initialization_r\n",
-    "!start cmd /C %WINPYDIR%\\\\..\\\\scripts\\\\R_launcher.bat --no-restore --no-save  %r_initialization_r%  "
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "#2019-08-26: this cell is  no more valid, so we don't know how to make it movable\n",
-    "# make RKernel a movable installation with the rest of WinPython \n",
-    "from winpython import utils\n",
-    "base_winpython = os.path.dirname(os.path.normpath(os.environ[\"WINPYDIR\"]))\n",
-    "rkernel_json=(base_winpython+\"\\\\settings\\\\kernels\\\\ir\\\\kernel.json\")\n",
-    "\n",
-    "# so we get \"argv\": [\"{prefix}/../tools/R/bin/x64/R\"\n",
-    "utils.patch_sourcefile(rkernel_json, base_winpython.replace(\"\\\\\",\"/\"), r'{prefix}/..', silent_mode=False)"
+    "with io.open(\"temp1.R\", 'w', encoding = sys.getdefaultencoding() ) as f:\n",
+    "    for line in Rscript_text.splitlines():\n",
+    "        f.write('%s\\n' %  line  )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4- Install a R package via a IPython  Kernel"
+    "### call R script\n",
+    "see status in the Windows terminal window"
    ]
   },
   {
@@ -239,18 +194,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext rpy2.ipython\n",
-    "\n",
-    "#vitals: 'dplyr', 'R.utils', 'nycflights13'\n",
-    "# installation takes 2 minutes\n",
-    "%R install.packages(c('dplyr','R.utils', 'nycflights13'), repos='http://cran.rstudio.com/') "
+    "Rscript_exe = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", \"R-Portable\", \"App\", \"R-Portable\", \"bin\", \"Rscript.exe\")\n",
+    "run(Rscript_exe+\" temp1.R\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5- Small demo via R magic"
+    "#### Fix the kernel.json to allow arbitrary drive letters\n",
+    "\n",
+    "the path to R is hardcoded in the kernel.json file. \n",
+    "this will cause trouble, if the drive letter of the usb drive changes. \n",
+    "use relative paths instead."
    ]
   },
   {
@@ -259,64 +215,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!echo %R_HOME%"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext rpy2.ipython"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# avoid some pandas deprecation warning\n",
-    "import warnings\n",
-    "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%R\n",
-    "library('dplyr')\n",
-    "library('nycflights13') \n",
-    "write.csv(flights, \"flights.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%R head(flights) "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%R airports %>% mutate(dest = faa) %>% semi_join(flights) %>% head"
+    "kernel_path = os.path.join(os.environ[\"WINPYDIRBASE\"], \"settings\", \"kernels\", \"ir\", \"kernel.json\")\n",
+    "assert os.path.isfile(kernel_path)\n",
+    "\n",
+    "with open(kernel_path, 'r') as f:\n",
+    "    kernel_str = f.read()\n",
+    "\n",
+    "new_kernel_str = kernel_str.replace(os.environ[\"WINPYDIRBASE\"].replace(\"\\\\\",\"/\"),\"{prefix}/..\")\n",
+    "print(new_kernel_str)\n",
+    "\n",
+    "with io.open(kernel_path, 'w', encoding = sys.getdefaultencoding() ) as f:\n",
+    "    for line in new_kernel_str.splitlines():\n",
+    "        f.write('%s\\n' %  line  )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 6 - Installing the very best of R pakages (optional, you will start to get a really big directory)\n"
+    "#### delete setup files"
    ]
   },
   {
@@ -325,57 +242,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# essentials: 'tidyr', 'shiny', 'ggplot2', 'caret' , 'nnet'  \n",
-    "# remaining of Hadley Wickahm \"stack\" (https://github.com/rstudio)\n",
-    "%R install.packages(c('tidyr', 'ggplot2',  'shiny','caret' , 'nnet'), repos='https://cran.rstudio.com/') \n",
-    "%R install.packages(c('knitr', 'purrr', 'readr', 'readxl'), repos='https://cran.rstudio.com/')\n",
-    "%R install.packages(c('rvest', 'lubridate', 'ggvis', 'readr','base64enc'), repos='https://cran.rstudio.com/')\n",
-    "\n",
-    "# TRAINING = online training book http://r4ds.had.co.nz/ (or https://github.com/hadley/r4ds)"
+    "os.remove(R_installer_fullpath)\n",
+    "os.remove(\"temp1.R\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 7 - Relaunch Jupyter Notebook to get a R kernel option\n",
-    "launch a new notebook of \"R\" type, and type in it:\n",
-    "    \n",
-    "library('dplyr')\n",
-    "\n",
-    "library('nycflights13') \n",
-    "\n",
-    "head(flights)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 9 - To Un-install  / Re-install R (or other trouble-shooting)\n",
-    "\n",
-    "- launch  winpython**\\t\\R\\unins000.exe   (was formerly winpython**\\tools\\R\\unins000.exe)\n",
-    "\n",
-    "- delete the directory winpython**\\t\\R (was formerly winpython**\\tools\\R)\n",
-    "\n",
-    "- re-install\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%R  install.packages(c('bindrccp'), repos='http://cran.rstudio.com/') "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -394,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This uses the most recent release from the [R portable](https://sourceforge.net/projects/rportable/) project for installation. 
To extract the files without user interaction (Run > Run All Cells) a copy of 7zip is downloaded and also kept in the `t` folder. 
Files are downloaded from the vorboss sourceforge server, since no http referer is needed here (not redirected back to sourceforge website). 

I am no R user and only checked `1+1 = 2`, so tests of R package installation and updating may be needed. 