### PR TITLE
fix regex for md5 hash file

### DIFF
--- a/docs/installing_julia_and_ijulia.ipynb
+++ b/docs/installing_julia_and_ijulia.ipynb
@@ -109,7 +109,7 @@
     "    julia_zip=ziplink32bit.split(\"/\")[-1]\n",
     "    julia_url=ziplink32bit\n",
     "    \n",
-    "hashes=(re.findall(r\"([0-9a-f]{32})\\s\"+julia_zip, md5hashes)[0] , re.findall(r\"([0-9a-f]{64})\\s+\"+julia_zip, sha256hashes)[0])\n",
+    "hashes=(re.findall(r\"([0-9a-f]{32})\\s+\"+julia_zip, md5hashes)[0] , re.findall(r\"([0-9a-f]{64})\\s+\"+julia_zip, sha256hashes)[0])\n",
     "    \n",
     "julia_zip_fullpath = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", julia_zip)\n",
     "\n",


### PR DESCRIPTION
It seems the hash sum files are not consistent regarding the amount of white space between the sum and the filename.
