### PR TITLE
Update octave installer to use octave-gui.exe with qt support

### DIFF
--- a/docs/installing_octave.ipynb
+++ b/docs/installing_octave.ipynb
@@ -105,7 +105,8 @@
    "outputs": [],
    "source": [
     "# Prepare environment variables\n",
-    "os.environ[\"OCTAVE_EXECUTABLE\"] = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", octave_version+\"-w64\", \"mingw64\", \"bin\", \"octave-cli.exe\")\n",
+    "os.environ[\"OCTAVE_EXECUTABLE\"] = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", octave_version+\"-w64\", \"mingw64\", \"bin\", \"octave.bat\")\n",
+    "os.environ[\"OCTAVE_CLI_OPTIONS\"] = '--no-gui'\n",
     "os.environ[\"OCTAVE_KERNEL_JSON\"] = os.path.join(os.environ[\"WINPYDIR\"], \"share\", \"jupyter\", \"kernels\", \"octave\", \"kernel.json\")"
    ]
   },
@@ -131,7 +132,8 @@
     "rem handle {0} if included\n",
     "rem ******************\n",
     "if not exist \"%WINPYDIRBASE%\\t\\{0}-w64\" goto {0}_bad\n",
-    "set OCTAVE_EXECUTABLE=%WINPYDIRBASE%\\t\\{0}-w64\\mingw64\\bin\\octave-cli.exe\n",
+    "set OCTAVE_EXECUTABLE=%WINPYDIRBASE%\\t\\{0}-w64\\mingw64\\bin\\octave.bat\n",
+    "set OCTAVE_CLI_OPTIONS=--no-gui\n",
     "set OCTAVE_KERNEL_JSON=%WINPYDIR%\\share\\jupyter\\kernels\\octave\\kernel.json\n",
     ":{0}_bad\n",
     "\"\"\".format(octave_version)\n",
@@ -140,11 +142,28 @@
     "with open(os.path.join(os.environ[\"WINPYDIRBASE\"],\"scripts\",\"env.bat\"), 'a') as file :\n",
     "    file.write(inp_str)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# change octave.bat to use `octave-gui.exe --no-gui` instead of `octave-cli`\n",
+    "octave_bat_path = os.path.join(os.environ[\"WINPYDIRBASE\"], \"t\", octave_version+\"-w64\", \"mingw64\", \"bin\", \"octave.bat\")\n",
+    "with io.open(octave_bat_path, 'r') as file:\n",
+    "    content = file.read()\n",
+    "\n",
+    "content.replace(\"octave-cli.exe %*\", \"call octave-gui.exe --no-gui %*\")\n",
+    "\n",
+    "with io.open(octave_bat_path, 'w') as file:\n",
+    "    file.write(content)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -158,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Jupyter octave kernel now uses the qt backend by default, see Calysto/octave_kernel#204 .
qt is not supported by octave-cli.exe. Switching to `octave-gui.exe --no-gui`.